### PR TITLE
Fix UsernameNotFoundException message and add test

### DIFF
--- a/src/main/java/com/yildiz/serhat/carleaseplatform/service/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/yildiz/serhat/carleaseplatform/service/impl/AuthenticationServiceImpl.java
@@ -52,7 +52,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                         request.email(),
                         request.password()));
         var user = repository.findByEmail(request.email())
-                .orElseThrow(() -> new UsernameNotFoundException(String.format("Username with email %s not found")));
+                .orElseThrow(() -> new UsernameNotFoundException(String.format("Username with email %s not found", request.email())));
         var jwtToken = jwtService.generateToken(user);
         revokeAllUserTokens(user);
         saveUserToken(user, jwtToken);

--- a/src/test/java/com/yildiz/serhat/carleaseplatform/service/impl/AuthenticationServiceImplTest.java
+++ b/src/test/java/com/yildiz/serhat/carleaseplatform/service/impl/AuthenticationServiceImplTest.java
@@ -1,0 +1,51 @@
+package com.yildiz.serhat.carleaseplatform.service.impl;
+
+import com.yildiz.serhat.carleaseplatform.configuration.JwtService;
+import com.yildiz.serhat.carleaseplatform.controller.request.AuthenticationRequest;
+import com.yildiz.serhat.carleaseplatform.repository.TokenRepository;
+import com.yildiz.serhat.carleaseplatform.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationServiceImplTest {
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private TokenRepository tokenRepository;
+    @Mock
+    private PasswordEncoder passwordEncoder;
+    @Mock
+    private JwtService jwtService;
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @InjectMocks
+    private AuthenticationServiceImpl authenticationService;
+
+    @Test
+    void authenticate_whenUserNotFound_throwsUsernameNotFoundException() {
+        AuthenticationRequest request = new AuthenticationRequest("missing@example.com", "password");
+        doNothing().when(authenticationManager).authenticate(any(UsernamePasswordAuthenticationToken.class));
+        when(userRepository.findByEmail(request.email())).thenReturn(Optional.empty());
+
+        UsernameNotFoundException ex = assertThrows(UsernameNotFoundException.class,
+                () -> authenticationService.authenticate(request));
+        assertEquals("Username with email missing@example.com not found", ex.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- fix missing argument in AuthenticationServiceImpl exception message
- add unit test for user-not-found scenario

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a25e05c50833280a5da338f088e39